### PR TITLE
Skip basic-auth for OPTIONS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headspace/fastboot-app-server",
-  "version": "1.0.0-rc.6",
+  "version": "1.1.0",
   "description": "A production-ready app server for running Ember FastBoot apps",
   "main": "src/fastboot-app-server.js",
   "scripts": {

--- a/src/basic-auth.js
+++ b/src/basic-auth.js
@@ -2,6 +2,11 @@ var basicAuth = require('basic-auth');
 
 module.exports = function(username, password) {
   return function(req, res, next) {
+    // Skip basic auth for options requests
+    if (req.method === 'OPTIONS') {
+      return next();
+    }
+
     var user = basicAuth(req);
 
     if (!user || user.name !== username || user.pass !== password) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,13 +1827,6 @@ fast-sourcemap-concat@^1.0.1:
     source-map "^0.4.2"
     source-map-url "^0.3.0"
 
-fastboot-express-middleware@^1.0.0-rc.4:
-  version "1.0.0-rc.8"
-  resolved "https://registry.yarnpkg.com/fastboot-express-middleware/-/fastboot-express-middleware-1.0.0-rc.8.tgz#449c4c5c6cc0ee5016a9f6399bc108fa707d39b2"
-  dependencies:
-    chalk "^1.1.3"
-    fastboot "^1.0.0-rc.5"
-
 "fastboot-express-middleware@https://github.com/jcblw/fastboot-express-middleware.git":
   version "1.0.0-rc.8"
   resolved "https://github.com/jcblw/fastboot-express-middleware.git#f77a189ee4195d665acd7d6f64cde87222196ab4"


### PR DESCRIPTION
## Description

Remove Basic Auth form OPTIONS requests to avoid a 401

## Context

Making a POST request to `/payment/paypal` fails during the OPTIONS request with a 401. 

## Screenshots
__With Change__
![Screen Shot 2019-03-14 at 12 45 00 PM](https://user-images.githubusercontent.com/5404649/54386832-1cc0b080-4657-11e9-8d3f-b8665ffff07d.png)

__Without Change__
<img width="1680" alt="Screen Shot 2019-03-08 at 12 31 03 PM" src="https://user-images.githubusercontent.com/5404649/54386864-32ce7100-4657-11e9-85ba-1a91c2f6c374.png">