### PR TITLE
Chore / Expose `sandboxGlobals` option to FastBootAppServer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ const FastBootAppServer = require('fastboot-app-server');
 let server = new FastBootAppServer({
   distPath: 'dist',
   gzip: true // Optional - Enables gzip compression.
+  sandboxGlobals: {
+    A_GLOBAL_VALUE: 'Some value accessible in the Ember client during SSR',
+    ANOTHER_GLOBAL_VALUE: {
+      passedInFrom: 'the Fastboot server instantiation'
+    }
+  }
 });
 
 server.start();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headspace/fastboot-app-server",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "A production-ready app server for running Ember FastBoot apps",
   "main": "src/fastboot-app-server.js",
   "scripts": {

--- a/src/fastboot-app-server.js
+++ b/src/fastboot-app-server.js
@@ -21,6 +21,7 @@ class FastBootAppServer {
     this.httpServer = options.httpServer;
     this.beforeMiddleware = options.beforeMiddleware;
     this.afterMiddleware = options.afterMiddleware;
+    this.sandboxGlobals = options.sandboxGlobals;
 
     if (!this.ui) {
       let UI = require('./ui');
@@ -39,7 +40,8 @@ class FastBootAppServer {
         password: this.password,
         httpServer: this.httpServer,
         beforeMiddleware: this.beforeMiddleware,
-        afterMiddleware: this.afterMiddleware
+        afterMiddleware: this.afterMiddleware,
+        sandboxGlobals: this.sandboxGlobals
       });
 
       this.worker.start();

--- a/src/worker.js
+++ b/src/worker.js
@@ -15,6 +15,7 @@ class Worker {
     this.password = options.password;
     this.beforeMiddleware = options.beforeMiddleware;
     this.afterMiddleware = options.afterMiddleware;
+    this.sandboxGlobals = options.sandboxGlobals;
 
     if (!this.httpServer) {
       this.httpServer = new ExpressHTTPServer({
@@ -66,6 +67,7 @@ class Worker {
   buildMiddleware() {
     this.fastboot = new FastBoot({
       distPath: this.distPath,
+      sandboxGlobals: this.sandboxGlobals,
     });
 
     return fastbootMiddleware({


### PR DESCRIPTION
The `FastBootAppServer` class exported from this package is an abstraction layer over the `FastBoot` class

This PR surfaces an option to add `sandboxGlobals`, which are global values injected into the "sandbox" of the Fastboot process (where our Ember site gets SSR'ed)
* The idea is to be able to pre-load some data when certain pages are SSR'ed

Fastboot reference (where this configuration gets passed into):
https://github.com/ember-fastboot/fastboot/blob/5a42df54ce3359a33589173d9c79a2236e619ba1/src/index.js#L27

```
 * #### Sandboxing
 *
 * For security and correctness reasons, Ember applications running in FastBoot
 * are run inside a sandbox that prohibits them from accessing the normal
 * Node.js environment.
 *
 * By default, this sandbox is the built-in `VMSandbox` class, which uses
 * Node's `vm` module. You may provide your own sandbox implementation by
 * passing the `sandbox` option or add and/or override sandbox variables by
 * passing the `addOrOverrideSandboxGlobals` option.
 *
 * @example
 * const FastBoot = require('fastboot');
 *
 * let app = new FastBoot({
 *   distPath: 'path/to/dist',
 *   sandbox: 'path/to/sandboxClass',
 *   sandboxGlobals: {...}
 * });
```